### PR TITLE
Transform defines in EventValueSource into enum

### DIFF
--- a/_P124_NeoPixelBusFX.ino
+++ b/_P124_NeoPixelBusFX.ino
@@ -1656,7 +1656,7 @@ void hex2rgb_pixel(String hexcolor) {
 // ---------------------------------------------------------------------------------
 // ------------------------------ JsonResponse -------------------------------------
 // ---------------------------------------------------------------------------------
-void NeoPixelSendStatus(byte eventSource) {
+void NeoPixelSendStatus(EventValueSource::Enum eventSource) {
   String log = String(F("NeoPixelBusFX: Set ")) + rgb.R
   + String(F("/")) + rgb.G + String(F("/")) + rgb.B;
   addLog(LOG_LEVEL_INFO, log);


### PR DESCRIPTION
ESPEasy has changed the event struct (see #94abb74c25b3c199857cc08d2d42e6a30070ebb9)